### PR TITLE
Adding a union type for Response

### DIFF
--- a/lib/siftsciex/verification/response.ex
+++ b/lib/siftsciex/verification/response.ex
@@ -7,6 +7,8 @@ defmodule Siftsciex.Verification.Response do
 
   alias Siftsciex.Verification.Response.Check, as: CheckResponse
   alias Siftsciex.Verification.Response.Send, as: SendResponse
+  
+  @type t :: CheckResponse.t() | SendResponse.t()
 
   @doc """
   Processes the respose from Sift Science Verification requests


### PR DESCRIPTION
`__MODULE__.t` on line 27 is cause compilation failures. Adding a union type of the two responses.