### PR TITLE
Fix @spec for Response

### DIFF
--- a/lib/siftsciex/verification/response.ex
+++ b/lib/siftsciex/verification/response.ex
@@ -24,7 +24,7 @@ defmodule Siftsciex.Verification.Response do
         status: 50
       }
   """
-  @spec process(String.t, String.t) :: __MODULE__.t
+  @spec process(String.t(), String.t()) :: CheckResponse.t()
   def process(response_body, endpoint) when is_binary(response_body) do
     response_body
     |> Poison.decode()


### PR DESCRIPTION
Fixes Elixir 1.11 preventing compiling because of reference to non-existing type.