### PR TITLE
[FUJI-68] Add support for Decisions API

### DIFF
--- a/lib/siftsciex/decision.ex
+++ b/lib/siftsciex/decision.ex
@@ -104,7 +104,6 @@ defmodule Siftsciex.Decision do
     "#{base_url()}/#{account_id}/#{entity_type}s/#{entity_id}/decisions"
   end
 
-  # defp base_url, do: Application.get_env(:siftsciex, :score_url)
   defp base_url, do: Application.get_env(:siftsciex, :decisions_url)
 
   defp credentials, do: "#{Application.get_env(:siftsciex, :api_key)}:" |> Base.encode64()

--- a/lib/siftsciex/decision.ex
+++ b/lib/siftsciex/decision.ex
@@ -5,6 +5,12 @@ defmodule Siftsciex.Decision do
   This data indicates that an action should be taken on the given "entity".  Webhooks are triggered either by conditions in one of your Workflows or manual actions taken in Sift Science by humans in your organization (reviewer actions).
   """
 
+  require Logger
+
+  alias Siftsciex.Decision.Response
+
+  @transport Application.get_env(:siftsciex, :http_transport) || HTTPoison
+
   defstruct [:entity, :decision, :time]
   @type t :: %__MODULE__{entity: entity, decision: String.t, time: DateTime.t}
   @type entity :: {entity_type, String.t}
@@ -14,6 +20,11 @@ defmodule Siftsciex.Decision do
                  "order" => :order,
                  "session" => :session,
                  "content" => :content}
+  @type result :: {:ok, Response.t}
+                  | {:error,  :redirected, String.t}
+                  | {:error, :client_error, integer}
+                  | {:error, :server_error, integer}
+                  | {:error, :transport_error, any}
 
   @doc """
   Creates a new `t:Siftsciex.Decision.t/0` struct from the given map (parsed JSON)
@@ -25,12 +36,46 @@ defmodule Siftsciex.Decision do
   ## Examples
 
       iex> Decision.new(%{"entity" => %{"type" => "user", "id" => "8"}, "decision" => %{"id" => "steralize"}, "time" => 1528813580})
-      %Decision{entity: {:user, "8"}, decision: "steralize", time: #DateTime<2018-06-12 14:26:20Z>}
-
+      %Decision{entity: {:user, "8"}, decision: "steralize", time: ~U[1970-01-18 16:40:13.580Z]}
   """
   @spec new(map) :: __MODULE__.t
   def new(body) do
     process(body)
+  end
+
+  @doc """
+  Retrieves the decisions for a given entity
+
+  ## Parameters
+
+    - `entity_id`: the ID of the entity you are looking to get decisions for
+    - `entity_type`: The type of the entity you are looking to get decisions for (see entity_type above)
+
+  ## Examples
+
+      iex> Decision.decisions_for("21123865", "user")
+      {:ok, %Siftsciex.Decision.Response{decisions: %{payment_abuse: %{decision: %{id: "auto_block_payment_abuse"},time: 1613777136497,webhook_succeeded: false}}}}
+  """
+  @spec decisions_for(String.t, entity_type) :: map
+  def decisions_for(entity_id, entity_type) do
+    account_id = Application.get_env(:siftsciex, :account_id)
+
+    entity_id
+    |> request_url(entity_type, account_id)
+    |> @transport.get([{"Authorization", "Basic #{credentials()}"}])
+    |> case do
+         {:ok, %{status_code: 200} = response} ->
+           {:ok, Response.process(response.body())}
+         {:ok, %{status_code: status} = response} when status >= 300 and status <= 399 ->
+           {:error, :redirected, response.headers["Location"]}
+         {:ok, %{status_code: status}} when status >= 400 and status <= 499 ->
+           Logger.error("Failed to Post Event, received 4xx response for configured URI")
+           {:error, :client_error, status}
+         {:ok, %{status_code: status}} when status >= 500 and status <= 500 ->
+           {:error, :server_error, status}
+         {:error, error} ->
+           {:error, :transport_error, error.reason()}
+       end
   end
 
   defp process(body) do
@@ -54,4 +99,13 @@ defmodule Siftsciex.Decision do
 
     time
   end
+
+  defp request_url(entity_id, entity_type, account_id) do
+    "#{base_url()}/#{account_id}/#{entity_type}s/#{entity_id}/decisions"
+  end
+
+  # defp base_url, do: Application.get_env(:siftsciex, :score_url)
+  defp base_url, do: Application.get_env(:siftsciex, :decisions_url)
+
+  defp credentials, do: "#{Application.get_env(:siftsciex, :api_key)}:" |> Base.encode64()
 end

--- a/lib/siftsciex/decision.ex
+++ b/lib/siftsciex/decision.ex
@@ -104,7 +104,7 @@ defmodule Siftsciex.Decision do
     "#{base_url()}/#{account_id}/#{entity_type}s/#{entity_id}/decisions"
   end
 
-  defp base_url, do: Application.get_env(:siftsciex, :decisions_url)
+  defp base_url, do: Application.get_env(:siftsciex, :accounts_url)
 
   defp credentials, do: "#{Application.get_env(:siftsciex, :api_key)}:" |> Base.encode64()
 end

--- a/lib/siftsciex/decision.ex
+++ b/lib/siftsciex/decision.ex
@@ -56,7 +56,7 @@ defmodule Siftsciex.Decision do
       iex> Decision.decisions_for("21123865", "user")
       {:ok, %Siftsciex.Decision.Response{decisions: %{payment_abuse: %{decision: %{id: "auto_block_payment_abuse"},time: 1613777136497,webhook_succeeded: false}}}}
   """
-  @spec decisions_for(String.t, entity_type) :: map
+  @spec decisions_for(String.t, entity_type) :: result
   def decisions_for(entity_id, entity_type) do
     account_id = Application.get_env(:siftsciex, :account_id)
 

--- a/lib/siftsciex/decision/response.ex
+++ b/lib/siftsciex/decision/response.ex
@@ -1,0 +1,38 @@
+defmodule Siftsciex.Decision.Response do
+  @moduledoc """
+  Represents a Decision API response
+  """
+
+  require Logger
+
+  defstruct decisions: :empty
+  @type t :: %__MODULE__{decisions: :empty | [Decision.t]}
+
+  @doc """
+  Processes a response body and converts it into a `t:Siftsciex.Decision.Response.t/0` struct.
+
+  ## Parameters
+
+    - `body`: A `String.t` representation of a Sift Science Decision Response
+
+  ## Examples
+      iex> Response.process("{\\"decisions\\":{\\"payment_abuse\\": {\\"decision\\": {\\"id\\": \\"auto_block_payment_abuse\\"},\\"time\\": 1613777136497,\\"webhook_succeeded\\": false}}}")
+      %Response{decisions: %{payment_abuse: %{decision: %{id: "auto_block_payment_abuse"},time: 1613777136497,webhook_succeeded: false}}}
+  """
+  @spec process(String.t | map) :: __MODULE__.t
+  def process(body) when is_binary(body) do
+    body
+    |> Poison.decode(keys: :atoms)
+    |> case do
+         {:ok, response} ->
+           process(response)
+         {:error, reason} ->
+           Logger.error("Invalid (#{reason}) JSON response from Sift Science: #{body}")
+           %__MODULE__{}
+       end
+  end
+  def process(body) do
+    __MODULE__
+    |> struct(body)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Siftsciex.MixProject do
       name: "Siftsciex",
       description: description(),
       package: package(),
-      version: "0.6.0",
+      version: "0.7.0",
       elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env),
       test_coverage: [tool: ExCoveralls],
@@ -50,9 +50,9 @@ defmodule Siftsciex.MixProject do
   defp package do
     [
       licenses: ["LGPLv3"],
-      maintainers: ["Glen Holcomb"],
-      links: %{"GitHub" => "https://github.com/apartmenttherapy/siftsciex"},
-      source_url: "https://github.com/apartmenttherapy/siftsciex"
+      maintainers: ["Derek Sweet"],
+      links: %{"GitHub" => "https://github.com/TheRealReal/siftsciex"},
+      source_url: "https://github.com/TheRealReal/siftsciex"
     ]
   end
 end

--- a/test/siftsciex/decision/response_test.exs
+++ b/test/siftsciex/decision/response_test.exs
@@ -1,0 +1,7 @@
+defmodule Siftsciex.Score.ResponseTest do
+  use ExUnit.Case
+
+  alias Siftsciex.Decision.Response
+
+  doctest Response
+end

--- a/test/siftsciex/decision_test.exs
+++ b/test/siftsciex/decision_test.exs
@@ -3,6 +3,8 @@ defmodule Siftsciex.DecisionTest do
 
   alias Siftsciex.Decision
 
+  doctest Decision
+
   test "new/1 builds a valid decision" do
     miliseconds = 1_528_813_580_000
     {:ok, expected_time} = DateTime.from_unix(miliseconds, :millisecond)

--- a/test/siftsciex/decision_test.exs
+++ b/test/siftsciex/decision_test.exs
@@ -5,6 +5,18 @@ defmodule Siftsciex.DecisionTest do
 
   doctest Decision
 
+  test "decisions_for/3 raises an error if a session entity is requested with no user_id" do
+    assert_raise RuntimeError, "Missing user_id for session or content URL", fn ->
+      Decision.decisions_for("1234", "session")
+    end
+  end
+
+  test "decisions_for/3 raises an error if a content entity is requested with no user_id" do
+    assert_raise RuntimeError, "Missing user_id for session or content URL", fn ->
+      Decision.decisions_for("1234", "content")
+    end
+  end
+
   test "new/1 builds a valid decision" do
     miliseconds = 1_528_813_580_000
     {:ok, expected_time} = DateTime.from_unix(miliseconds, :millisecond)

--- a/test/support/mock_request.ex
+++ b/test/support/mock_request.ex
@@ -72,6 +72,10 @@ defmodule Siftsciex.Support.MockRequest do
     {:ok, %{status_code: 200, body: score_response()}}
   end
 
+  def get(_url, _headers) do
+    {:ok, %{status_code: 200, body: decision_response()}}
+  end
+
   defp score_response do
     """
     {
@@ -86,6 +90,22 @@ defmodule Siftsciex.Support.MockRequest do
               "name": "Dirty"
             }
           ]
+        }
+      }
+    }
+    """
+  end
+
+  defp decision_response do
+    """
+    {
+      "decisions": {
+        "payment_abuse": {
+          "decision": {
+            "id": "auto_block_payment_abuse"
+          },
+          "time": 1613777136497,
+          "webhook_succeeded": false
         }
       }
     }

--- a/test/support/mock_request.ex
+++ b/test/support/mock_request.ex
@@ -72,8 +72,12 @@ defmodule Siftsciex.Support.MockRequest do
     {:ok, %{status_code: 200, body: score_response()}}
   end
 
-  def get(_url, _headers) do
-    {:ok, %{status_code: 200, body: decision_response()}}
+  def get(url, _headers) do
+    if String.contains?(url, "sessions") do
+      {:ok, %{status_code: 200, body: sessions_decision_response()}}
+    else
+      {:ok, %{status_code: 200, body: decision_response()}}
+    end
   end
 
   defp score_response do
@@ -103,6 +107,22 @@ defmodule Siftsciex.Support.MockRequest do
         "payment_abuse": {
           "decision": {
             "id": "auto_block_payment_abuse"
+          },
+          "time": 1613777136497,
+          "webhook_succeeded": false
+        }
+      }
+    }
+    """
+  end
+
+  defp sessions_decision_response do
+    """
+    {
+      "decisions": {
+        "payment_abuse": {
+          "decision": {
+            "id": "session_blocked_account_takeover"
           },
           "time": 1613777136497,
           "webhook_succeeded": false


### PR DESCRIPTION
[FUJI-68](https://trr-test.atlassian.net/browse/FUJI-68?atlOrigin=eyJpIjoiNjI4MzFhZmVmYzg4NGQzMTk1ODk1Y2FmODBjYjg5OGYiLCJwIjoiaiJ9)

## Description
In order to display the user's most recent payment protection decisions on the Client View page, we need to modify the Siftsciex library to support the most basic version of the decisions API, allowing it to retrieve decisions for a given entity (user, order, etc..). This PR introduces the changes necessary so that you can specify an `entity_id` and `entity_type` and it will return the decisions for that entity. 

## Motivation and Context
Allow us to retrieve an entity's latest decisions for display on the Client View page 

## Type of Changes
<!-- What type of changes does your code introduce? -->
<!-- Put an `[x]` in any of the boxes that apply: -->
- [ ] Bug fix _(a non-breaking change which fixes an issue)_
- [ x ] New feature _(a non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that changes existing functionality)_
- [ ] Bump dependencies
- [ ] Automated Testing / Missing tests
- [ ] Documentation

## Checklist:
<!-- Verify the following points and put an `[x]` in the boxes that apply: -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] Yes, I have added tests to cover my changes.
- [ ] No, We don't have a test suite in this project yet.
- [ ] My change requires a change to the documentation.
- [ ] My change requires release strategy _(uncomment the Release strategy below)_
