### PR TITLE
[FUJI-92] Update the URL used for getting a user's score

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -4,5 +4,6 @@ config :siftsciex,
   currency_factors: [usd: {Siftsciex.Support.Converter, :usd}],
   api_key: "test_key",
   events_url: "https://api.siftscience.com/v205/events",
+  users_url: "https://api.siftscience.com/v205/users",
   score_url: "https://api.siftscience.com/v205/score",
   http_transport: Siftsciex.Support.MockRequest

--- a/lib/siftsciex/score.ex
+++ b/lib/siftsciex/score.ex
@@ -66,14 +66,14 @@ defmodule Siftsciex.Score do
        end
   end
 
-  defp request_url(user, types) do
-    uri = "#{base_url()}/#{user}"
+  defp request_url(user_id, types) do
+    uri = "#{base_url()}/#{user_id}/score"
     query = "?api_key=#{api_key()}&abuse_types=#{abuse_val(types)}"
 
     "#{uri}/#{query}"
   end
 
-  defp base_url, do: Application.get_env(:siftsciex, :score_url)
+  defp base_url, do: Application.get_env(:siftsciex, :users_url)
 
   defp api_key, do: Application.get_env(:siftsciex, :api_key)
 


### PR DESCRIPTION
[FUJI-92](https://trr-prod.atlassian.net/browse/FUJI-92)

## Description
The `siftsciex` code we built this fork off of is pointing at a deprecated URL for obtaining a user's scores from Sift's API. The one it is pointing to now seems to reset the user's score rather than retrieve it. It has been confirmed by Sift that the old endpoint the library was using is no longer in use and should be deprecated in `siftsciex`. This change simply points the same function at `/users/{user_id}/score` rather than `/score/{user_id}`, everything else is identical in the structure of the response and everything. 

You can find Sift's documentation for this endpoint here: https://sift.com/developers/docs/curl/score-api/get-score/overview

## Motivation and Context
- Fix our bug so that simply viewing a user in Admin Client View doesn't reset their score

## Testing
- We can probably skip QA on this one, just want to get the fix out

## Type of Changes
<!-- What type of changes does your code introduce? -->
<!-- Put an `[x]` in any of the boxes that apply: -->
- [ x ] Bug fix _(a non-breaking change which fixes an issue)_
- [ ] New feature _(a non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that changes existing functionality)_
- [ ] Bump dependencies
- [ ] Automated Testing / Missing tests
- [ ] Documentation

## Checklist:
<!-- Verify the following points and put an `[x]` in the boxes that apply: -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Yes, I have added tests to cover my changes.
- [ ] No, We don't have a test suite in this project yet.
- [ ] My change requires a change to the documentation.
- [ ] My change requires release strategy _(uncomment the Release strategy below)_
