### PR TITLE
[#178109577] Synchronous workflow response support

### DIFF
--- a/lib/siftsciex/event/transport.ex
+++ b/lib/siftsciex/event/transport.ex
@@ -11,9 +11,17 @@ defmodule Siftsciex.Event.Transport do
 
     transporter().post(url(), json)
   end
+
   def post(payload, [scores: scores]) do
     {:ok, json} = Poison.encode(payload)
     query = "?return_score=true&abuse_types=#{Enum.join(scores, ",")}"
+
+    transporter().post(url() <> query, json)
+  end
+
+  def post(payload, [return_workflow_status: true]) do
+    {:ok, json} = Poison.encode(payload)
+    query = "?return_workflow_status=true"
 
     transporter().post(url() <> query, json)
   end

--- a/lib/siftsciex/score/response.ex
+++ b/lib/siftsciex/score/response.ex
@@ -5,18 +5,21 @@ defmodule Siftsciex.Score.Response do
 
   require Logger
 
-  alias Siftsciex.Score.Response.{Score, Label}
+  alias Siftsciex.Score.Response.{Score, Label, WorkflowStatus}
 
   defstruct status: :empty,
             error_message: :empty,
             user_id: :empty,
             scores: :empty,
-            latest_labels: :empty
+            latest_labels: :empty,
+            workflow_statuses: :empty
+
   @type t :: %__MODULE__{status: :empty | integer,
                          error_message: :empty | String.t,
                          user_id: :empty | String.t,
                          scores: :empty | [Score.t],
-                         latest_labels: :empty | [Label.t]}
+                         latest_labels: :empty | [Label.t],
+                         workflow_statuses: :empty | [WorkflowStatus.t]}
 
   @doc """
   Processes a response body and converts it into a `t:Siftsciex.Score.Response.t/0` struct.
@@ -39,10 +42,11 @@ defmodule Siftsciex.Score.Response do
          {:ok, response} ->
            process(response)
          {:error, reason} ->
-           Logger.error("Invalid (#{reason}) JSON response from Sift Science: #{body}")
+           Logger.error("Invalid (#{inspect(reason)}) JSON response from Sift Science: #{inspect(body)}")
            %__MODULE__{}
        end
   end
+
   def process(body) do
     __MODULE__
     |> struct(body)
@@ -53,6 +57,7 @@ defmodule Siftsciex.Score.Response do
     record
     |> convert_scores(record.scores())
     |> convert_labels(record.latest_labels())
+    |> convert_workflow_statuses(record.workflow_statuses())
   end
 
   defp convert_scores(record, :empty), do: record
@@ -69,5 +74,10 @@ defmodule Siftsciex.Score.Response do
   end
   defp convert_labels(record, labels) do
     struct(record, latest_labels: Label.new(labels))
+  end
+
+  defp convert_workflow_statuses(record, :empty), do: record
+  defp convert_workflow_statuses(record, workflow_statuses) do
+    struct(record, workflow_statuses: WorkflowStatus.new(workflow_statuses))
   end
 end

--- a/lib/siftsciex/score/response/label.ex
+++ b/lib/siftsciex/score/response/label.ex
@@ -5,11 +5,16 @@ defmodule Siftsciex.Score.Response.Label do
 
   alias Siftsciex.Score
 
-  defstruct type: :empty, is_bad: :empty, time: :empty, description: :empty
-  @type t :: %__MODULE__{type: :empty | Score.abuse_type,
-                         is_bad: :empty | boolean,
-                         time: :empty | DateTime.t,
-                         description: :empty | String.t}
+  defstruct is_bad: :empty, time: :empty, description: :empty
+
+  @type abuse_type :: :payment_abuse | :account_abuse | :content_abuse | :promotion_abuse
+  @type label :: %__MODULE__{
+          is_bad: :empty | boolean,
+          time: :empty | DateTime.t(),
+          description: :empty | String.t()
+        }
+
+  @type t :: %{abuse_type => label}
 
   @doc """
   Creates a new Label record from a Sift Science Score response
@@ -21,16 +26,21 @@ defmodule Siftsciex.Score.Response.Label do
   ## Examples
 
       iex> Label.new(%{payment_abuse: %{is_bad: true, time: 1529011047, description: "Fake card"}})
-      %Label{type: :payment_abuse, is_bad: true, time: #DateTime<2018-06-14 21:17:27Z>, description: "Fake card"}
+      %{payment_abuse: %Label{is_bad: true, time: #DateTime<2018-06-14 21:17:27Z>, description: "Fake card"}
 
   """
-  @spec new(map) :: __MODULE__.t
+  @spec new(map) :: t
   def new(label_data) do
-    [{type, data}] = Map.to_list(label_data)
+    label_data
+    |> Map.to_list()
+    |> Map.new(fn {type, data} ->
+      parsed =
+        %__MODULE__{}
+        |> struct(data)
+        |> convert_time()
 
-    %__MODULE__{type: type}
-    |> struct(data)
-    |> convert_time()
+      {type, parsed}
+    end)
   end
 
   defp convert_time(record) do

--- a/lib/siftsciex/score/response/workflow_status.ex
+++ b/lib/siftsciex/score/response/workflow_status.ex
@@ -1,0 +1,78 @@
+defmodule Siftsciex.Score.Response.WorkflowStatus do
+  @moduledoc """
+  Represents an item in the `workflow_statuses`  field in the
+  `Siftsciex.Score.Response.t()` struct
+  """
+  alias __MODULE__.{Config, Entity, Stage}
+
+  defstruct id: :empty,
+            state: :empty,
+            abuse_types: :empty,
+            config: :empty,
+            config_display_name: :empty,
+            entity: :empty,
+            history: :empty
+
+  @type abuse_type :: :payment_abuse | :promotion_abuse | :content_abuse | :account_abuse | :account_takeover | :legacy
+
+  @type t :: %__MODULE__{
+    id: String.t(),
+    state: :running | :finishd | :failed | :empty,
+    abuse_types: [abuse_type()] | :empty,
+    config: Config.t() | :empty,
+    config_display_name: String.t() | :empty,
+    entity: Entity.t() | :empty,
+    history: [Stage.t()] | :empty
+  }
+
+  @doc """
+  Converts a map to a  `t()` record or a list of maps into a list of `t()` records.
+
+  ## Parameters
+    - `data`: a map or list of maps
+
+  ## Examples
+
+      iex> WorkflowStatus.new(%{id: "an-id", state: "finished", entity: %{id: "entity-id", type: "content"}})
+      %WorkflowStatus{abuse_types: :empty, config: :empty, config_display_name: :empty, entity: %#{Entity}{id: "entity-id", type: :content}, history: :empty, id: "an-id", state: :finished}
+
+  """
+  @spec new(map | [map]) :: t | [t]
+  def new(data) when is_list(data), do: Enum.map(data, &convert/1)
+  def new(data), do: convert(data)
+
+  defp convert(data) do
+    %__MODULE__{}
+    |> struct(data)
+    |> convert_app()
+    |> convert_abuse_types()
+    |> convert_config()
+    |> convert_entity()
+    |> convert_history()
+  end
+
+  defp convert_app(%{state: :empty} = record), do: record
+  defp convert_app(%{state: state} = record) do
+    struct(record, state: String.to_existing_atom(state))
+  end
+
+  defp convert_abuse_types(%{abuse_types: :empty} = record), do: record
+  defp convert_abuse_types(%{abuse_types: abuse_types} = record) do
+    struct(record, abuse_types: Enum.map(abuse_types, &String.to_existing_atom/1))
+  end
+
+  defp convert_config(%{config: :empty} = record), do: record
+  defp convert_config(%{config: config} = record) do
+    struct(record, config: Config.new(config))
+  end
+
+  defp convert_entity(%{entity: :empty} = record), do: record
+  defp convert_entity(%{entity: entity} = record) do
+    struct(record, entity: Entity.new(entity))
+  end
+
+  defp convert_history(%{history: :empty} = record), do: record
+  defp convert_history(%{history: history} = record) do
+    struct(record, history: Stage.new(history))
+  end
+end

--- a/lib/siftsciex/score/response/workflow_status/button.ex
+++ b/lib/siftsciex/score/response/workflow_status/button.ex
@@ -1,0 +1,35 @@
+defmodule Siftsciex.Score.Response.WorkflowStatus.Button do
+  @moduledoc """
+  Represents the `buttons`  field in the `Siftsciex.Score.Response.WorkflowStatus.StageConfig.t()` struct
+  """
+  defstruct id: :empty, name: :empty
+
+  @type t :: %__MODULE__{
+          id: String.t() | :empty,
+          name: String.t() | :empty
+        }
+
+
+  @doc """
+  Converts a map or a list of maps to a `t()` struct or a list of `t()` structs.
+
+  ## Parameters
+    - data: a map or list of maps that should be converted to the `t()` struct
+
+  ## Example
+
+      iex> Button.new(%{id: "An Id", name: "A button name"})
+      %Button{id: "An Id", name: "A button name"}
+
+      iex> Button.new([%{id: "An Id", name: "A button name"}, %{id: "Another Id", name: "Another button name"}])
+      [%Button{id: "An Id", name: "A button name"}, %Button{id: "Another Id", name: "Another button name"}]
+
+  """
+  @spec new(map() | [map()]) :: t() | [t()]
+  def new(data) when is_list(data), do: Enum.map(data, &parse/1)
+  def new(data), do: parse(data)
+
+  defp parse(data) do
+    struct(%__MODULE__{}, data)
+  end
+end

--- a/lib/siftsciex/score/response/workflow_status/config.ex
+++ b/lib/siftsciex/score/response/workflow_status/config.ex
@@ -1,0 +1,28 @@
+defmodule Siftsciex.Score.Response.WorkflowStatus.Config do
+  @moduledoc """
+  Represents the `config`  field in the `Siftsciex.Score.Response.WorkflowStatus.t()` struct
+  """
+
+  defstruct id: :empty, version: :empty
+
+  @type t :: %__MODULE__{
+          id: String.t() | :empty,
+          version: String.t() | :empty
+        }
+
+  @doc """
+  Converts a map into a `t()` struct.
+
+  ## Parameters
+
+    - map: a map that should be converted to the `t()` struct.
+
+  ## Examples
+
+      iex> Config.new(%{id: "some-id", version: "some-version"})
+      %Config{id: "some-id", version: "some-version"}
+
+  """
+  @spec new(map) :: t
+  def new(data), do: struct(__MODULE__, data)
+end

--- a/lib/siftsciex/score/response/workflow_status/entity.ex
+++ b/lib/siftsciex/score/response/workflow_status/entity.ex
@@ -1,0 +1,38 @@
+defmodule Siftsciex.Score.Response.WorkflowStatus.Entity do
+  @moduledoc """
+  Represents the `entity`  field in the `Siftsciex.Score.Response.WorkflowStatus.t()` struct
+  """
+
+  defstruct id: :empty, type: :empty
+
+  @type type :: :user | :order | :content | :session
+  @type t :: %__MODULE__{
+          id: String.t() | :empty,
+          type: type() | :empty
+        }
+
+  @doc """
+  Converts a map into a `t()` struct.
+
+  ## Parameters
+
+    - map: a map that should be converted to the `t()` struct.
+
+  ## Examples
+
+      iex> Entity.new(%{id: "some-id", type: "session"})
+      %Entity{id: "some-id", type: :session}
+
+  """
+  @spec new(map()) :: t()
+  def new(data) do
+    %__MODULE__{}
+    |> struct(data)
+    |> convert_type()
+  end
+
+  defp convert_type(%{type: :empty} = record), do: record
+  defp convert_type(%{type: type} = record) do
+    struct(record, type: String.to_existing_atom(type))
+  end
+end

--- a/lib/siftsciex/score/response/workflow_status/stage.ex
+++ b/lib/siftsciex/score/response/workflow_status/stage.ex
@@ -1,0 +1,56 @@
+defmodule Siftsciex.Score.Response.WorkflowStatus.Stage do
+  @moduledoc """
+  Represents an item in the `history` field in the `Siftsciex.Score.Response.WorkflowStatus.Stage.t()` struct
+  """
+  alias Siftsciex.Score.Response.WorkflowStatus.StageConfig
+
+  defstruct app: :empty,
+            name: :empty,
+            state: :empty,
+            config: :empty
+
+  @type state :: :running | :finished | :failed
+
+  @type t :: %__MODULE__{
+    app: String.t() | :empty,
+    name: String.t() | :empty,
+    state: state() | :empty,
+    config: StageConfig.t() | :empty
+  }
+
+  @doc """
+  Converts a map to a  `t()` record or a list of maps into a list of `t()` records.
+
+  ## Parameters
+    - `data`: a map or list of maps to be converted
+
+  ## Example
+
+      iex> Stage.new(%{})
+      %Stage{app: :empty, name: :empty, state: :empty, config: :empty}
+
+      iex> Stage.new(%{app: "user_scorer", name: "decision", state: "finished", config: %{decision_id: "a_decision_id"}})
+      %Stage{app: "user_scorer", name: "decision", state: :finished, config: %#{StageConfig}{decision_id: "a_decision_id", buttons: :empty}}
+
+  """
+  @spec new(map | [map]) :: t | [t]
+  def new(data) when is_list(data), do: Enum.map(data, &parse/1)
+  def new(data), do: parse(data)
+
+  defp parse(data) do
+    %__MODULE__{}
+    |> struct(data)
+    |> convert_config()
+    |> convert_state()
+  end
+
+  defp convert_config(%{config: :empty} = record), do: record
+  defp convert_config(%{config: config} = record) do
+    struct(record, config: StageConfig.new(config))
+  end
+
+  defp convert_state(%{state: :empty} = record), do: record
+  defp convert_state(%{state: state} = record) do
+    struct(record, state: String.to_existing_atom(state))
+  end
+end

--- a/lib/siftsciex/score/response/workflow_status/stage_config.ex
+++ b/lib/siftsciex/score/response/workflow_status/stage_config.ex
@@ -1,0 +1,39 @@
+defmodule Siftsciex.Score.Response.WorkflowStatus.StageConfig do
+  @moduledoc """
+  Represents the `config`  field in the `Siftsciex.Score.Response.WorkflowStatus.Stage.t()` struct
+  """
+  alias Siftsciex.Score.Response.WorkflowStatus.Button
+
+  defstruct decision_id: :empty,
+            buttons: :empty
+
+  @type t :: %__MODULE__{
+    decision_id: String.t | :empty,
+    buttons: [Button.t] | :empy
+  }
+
+  @doc """
+  Converts a map into a `t()` struct.
+
+  ## Parameters
+
+    - map: a map that should be converted to the `t()` struct.
+
+  ## Examples
+
+      iex> StageConfig.new(%{decision_id: "some-id", buttons: [%{id: "button-id", name: "button-name"}]})
+      %StageConfig{decision_id: "some-id", buttons: [%#{Button}{id: "button-id", name: "button-name"}]}
+
+  """
+  @spec new(map()) :: t()
+  def new(data) do
+    %__MODULE__{}
+    |> struct(data)
+    |> convert_buttons()
+  end
+
+  defp convert_buttons(%{buttons: :empty} = record), do: record
+  defp convert_buttons(%{buttons: buttons} = record) do
+    struct(record, buttons: Button.new(buttons))
+  end
+end

--- a/test/siftsciex/score/response/label_test.exs
+++ b/test/siftsciex/score/response/label_test.exs
@@ -5,8 +5,8 @@ defmodule Siftsciex.Score.Response.LabelTest do
 
   doctest Label, except: [new: 1]
 
-  test "new/1 returns a label struct" do
-    expected = %Label{type: :payment_abuse, is_bad: true, time: expected_time(), description: "Fake card"}
+  test "new/1 returns a label map" do
+    expected = %{payment_abuse: %Label{is_bad: true, time: expected_time(), description: "Fake card"}}
 
     assert ^expected = Label.new(%{payment_abuse: %{is_bad: true, time: 1_529_011_047, description: "Fake card"}})
   end

--- a/test/siftsciex/score/response/workflow_status/button_test.exs
+++ b/test/siftsciex/score/response/workflow_status/button_test.exs
@@ -1,0 +1,7 @@
+defmodule Siftsciex.Score.Response.WorkflowStatus.ButtonTest do
+  use ExUnit.Case
+
+  alias Siftsciex.Score.Response.WorkflowStatus.Button
+
+  doctest Button
+end

--- a/test/siftsciex/score/response/workflow_status/config_test.exs
+++ b/test/siftsciex/score/response/workflow_status/config_test.exs
@@ -1,0 +1,7 @@
+defmodule Siftsciex.Score.Response.WorkflowStatus.ConfigTest do
+  use ExUnit.Case
+
+  alias Siftsciex.Score.Response.WorkflowStatus.Config
+
+  doctest Config
+end

--- a/test/siftsciex/score/response/workflow_status/entity_test.exs
+++ b/test/siftsciex/score/response/workflow_status/entity_test.exs
@@ -1,0 +1,7 @@
+defmodule Siftsciex.Score.Response.WorkflowStatus.EntityTest do
+  use ExUnit.Case
+
+  alias Siftsciex.Score.Response.WorkflowStatus.Entity
+
+  doctest Entity
+end

--- a/test/siftsciex/score/response/workflow_status/stage_config_test.exs
+++ b/test/siftsciex/score/response/workflow_status/stage_config_test.exs
@@ -1,0 +1,7 @@
+defmodule Siftsciex.Score.Response.WorkflowStatus.StageConfigTest do
+  use ExUnit.Case
+
+  alias Siftsciex.Score.Response.WorkflowStatus.StageConfig
+
+  doctest StageConfig
+end

--- a/test/siftsciex/score/response/workflow_status/stage_test.exs
+++ b/test/siftsciex/score/response/workflow_status/stage_test.exs
@@ -1,0 +1,7 @@
+defmodule Siftsciex.Score.Response.WorkflowStatus.StageTest do
+  use ExUnit.Case
+
+  alias Siftsciex.Score.Response.WorkflowStatus.Stage
+
+  doctest Stage
+end

--- a/test/siftsciex/score/response/workflow_status_test.exs
+++ b/test/siftsciex/score/response/workflow_status_test.exs
@@ -1,0 +1,7 @@
+defmodule Siftsciex.Score.Response.WorkflowStatusTest do
+  use ExUnit.Case
+
+  alias Siftsciex.Score.Response.WorkflowStatus
+
+  doctest WorkflowStatus
+end

--- a/test/siftsciex/score/response_test.exs
+++ b/test/siftsciex/score/response_test.exs
@@ -4,4 +4,209 @@ defmodule Siftsciex.Score.ResponseTest do
   alias Siftsciex.Score.Response
 
   doctest Response
+
+  describe "synchronous workflow" do
+    @response_body """
+    {
+      "status":0,
+      "error_message":"OK",
+      "user_id":"billy_jones_301",
+      "scores":{
+        "payment_abuse":{
+          "score":0.898391231245,
+          "reasons":[
+            {
+              "name":"UsersPerDevice",
+              "value":4,
+              "details":{
+                "users":"a, b, c, d"
+              }
+            }
+          ]
+        },
+        "promotion_abuse":{
+          "score":0.472838192111,
+          "reasons":[
+
+          ]
+        }
+      },
+      "latest_labels":{
+        "payment_abuse":{
+          "is_fraud":true,
+          "time":1352201880,
+          "description":"received a chargeback"
+        },
+        "promotion_abuse":{
+          "is_fraud":false,
+          "time":1362205000
+        }
+      },
+      "workflow_statuses":[
+        {
+          "id":"6dbq76qbaaaaa",
+          "state":"running",
+          "config":{
+            "id":"pv3u5hyaaa",
+            "version":"1468013109122"
+          },
+          "config_display_name":"my create order flow",
+          "abuse_types":[
+            "payment_abuse",
+            "legacy"
+          ],
+          "entity":{
+            "type":"user",
+            "id":"test"
+          },
+          "history":[
+            {
+              "app":"decision",
+              "name":"ban user",
+              "state":"running",
+              "config":{
+                "decision_id":"ban-user-payment-abuse"
+              }
+            },
+            {
+              "app":"review_queue",
+              "name":"risky user queue",
+              "state":"finished",
+              "config":{
+                "buttons":[
+                  {
+                    "id":"ban-user-payment-abuse",
+                    "name":"Ban User"
+                  },
+                  {
+                    "id":"suspend-user-payment-abuse",
+                    "name":"Ban User"
+                  },
+                  {
+                    "id":"accept-user-payment-abuse",
+                    "name":"Ban User"
+                  }
+                ]
+              }
+            },
+            {
+              "app":"user_scorer",
+              "name":"Entity",
+              "state":"finished"
+            },
+            {
+              "app":"event_processor",
+              "name":"Event",
+              "state":"finished"
+            }
+          ]
+        }
+      ]
+    }
+    """
+
+    test "parsed the response" do
+      expected =
+      %Siftsciex.Score.Response{
+        error_message: "OK",
+        latest_labels: %{
+          payment_abuse: %Siftsciex.Score.Response.Label{
+            description: "received a chargeback",
+            is_bad: :empty,
+            time: ~U[2012-11-06 11:38:00Z]
+          },
+          promotion_abuse: %Siftsciex.Score.Response.Label{
+            description: :empty,
+            is_bad: :empty,
+            time: ~U[2013-03-02 06:16:40Z]
+          }
+        },
+        scores: [
+          %Siftsciex.Score.Response.Score{
+            reasons: [
+              %Siftsciex.Score.Response.Reason{
+                details: %{users: "a, b, c, d"},
+                name: "UsersPerDevice",
+                value: 4
+              }
+            ],
+            score: 0.898391231245,
+            type: :payment_abuse
+          },
+          %Siftsciex.Score.Response.Score{
+            reasons: [],
+            score: 0.472838192111,
+            type: :promotion_abuse
+          }
+        ],
+        status: 0,
+        user_id: "billy_jones_301",
+        workflow_statuses: [
+          %Siftsciex.Score.Response.WorkflowStatus{
+            abuse_types: [:payment_abuse, :legacy],
+            config: %Siftsciex.Score.Response.WorkflowStatus.Config{
+              id: "pv3u5hyaaa",
+              version: "1468013109122"
+            },
+            config_display_name: "my create order flow",
+            entity: %Siftsciex.Score.Response.WorkflowStatus.Entity{
+              id: "test",
+              type: :user
+            },
+            history: [
+              %Siftsciex.Score.Response.WorkflowStatus.Stage{
+                app: "decision",
+                config: %Siftsciex.Score.Response.WorkflowStatus.StageConfig{
+                  buttons: :empty,
+                  decision_id: "ban-user-payment-abuse"
+                },
+                name: "ban user",
+                state: :running
+              },
+              %Siftsciex.Score.Response.WorkflowStatus.Stage{
+                app: "review_queue",
+                config: %Siftsciex.Score.Response.WorkflowStatus.StageConfig{
+                  buttons: [
+                    %Siftsciex.Score.Response.WorkflowStatus.Button{
+                      id: "ban-user-payment-abuse",
+                      name: "Ban User"
+                    },
+                    %Siftsciex.Score.Response.WorkflowStatus.Button{
+                      id: "suspend-user-payment-abuse",
+                      name: "Ban User"
+                    },
+                    %Siftsciex.Score.Response.WorkflowStatus.Button{
+                      id: "accept-user-payment-abuse",
+                      name: "Ban User"
+                    }
+                  ],
+                  decision_id: :empty
+                },
+                name: "risky user queue",
+                state: :finished
+              },
+              %Siftsciex.Score.Response.WorkflowStatus.Stage{
+                app: "user_scorer",
+                config: :empty,
+                name: "Entity",
+                state: :finished
+              },
+              %Siftsciex.Score.Response.WorkflowStatus.Stage{
+                app: "event_processor",
+                config: :empty,
+                name: "Event",
+                state: :finished
+              }
+            ],
+            id: "6dbq76qbaaaaa",
+            state: :running
+          }
+        ]
+      }
+
+      result = Response.process(@response_body)
+
+      assert result == expected
+    end
+  end
 end


### PR DESCRIPTION
## Description

[PT-178109577](https://www.pivotaltracker.com/story/show/178109577)

This PR adds support for the `return_workflow_status=true` option on the Siftsciex library

Most part is just parsing maps to structs.

## Changes

- Adds support for the `return_workflow_status` option when submitting an event.
- Adds a new field, `workflow_statuses`, into the `Siftsciex.Score.Response` struct - and structs for all child nodes.
- Tests and doctests

[More details on the official docs](https://sift.com/developers/docs/curl/workflows-api/running-workflows/synchronous)