### PR TITLE
[ZION-661] Better error handling for events

### DIFF
--- a/lib/siftsciex/event.ex
+++ b/lib/siftsciex/event.ex
@@ -36,7 +36,7 @@ defmodule Siftsciex.Event do
 
   require Logger
 
-  alias Siftsciex.Event.{Account, Content, Login, Response, Transport}
+  alias Siftsciex.Event.{Account, Content, Error, Login, Response, Transport}
 
   @type error_map :: %{required(String.t) => String.t}
   @type result :: {:ok, Response.t}
@@ -210,17 +210,21 @@ defmodule Siftsciex.Event do
 
   defp process_response(response) do
     case response do
-      {:ok, %{status_code: 200} = response} ->
-        {:ok, Response.process(response.body())}
-      {:ok, %{status_code: status} = response} when status >= 300 and status <= 399 ->
-        {:error, :redirected, response.headers["Location"]}
-      {:ok, %{status_code: status}} when status >= 400 and status <= 499 ->
+      {:ok, %{status_code: 200, body: body}} ->
+        {:ok, Response.process(body)}
+
+      {:ok, %{status_code: status, headers: headers}} when status >= 300 and status <= 399 ->
+        {:error, Error.build(:redirected, headers["Location"])}
+
+      {:ok, %{status_code: status, body: body}} when status >= 400 and status <= 499 ->
         Logger.error("Failed to Post Event, received 4xx response for configured URI")
-        {:error, :client_error, status}
-      {:ok, %{status_code: status}} when status >= 500 and status <= 500 ->
-        {:error, :server_error, status}
-      {:error, error} ->
-        {:error, :transport_error, error.reason()}
+        {:error, Error.from_body(:client_error, body)}
+
+      {:ok, %{status_code: status, body: body}} when status >= 500 and status <= 500 ->
+        {:error, Error.from_body(:server_error, body)}
+
+      {:error, %{reason: reason}} ->
+        {:error, Error.build(:transport_error, reason)}
     end
   end
 

--- a/lib/siftsciex/event.ex
+++ b/lib/siftsciex/event.ex
@@ -39,11 +39,7 @@ defmodule Siftsciex.Event do
   alias Siftsciex.Event.{Account, Content, Error, Login, Response, Transport}
 
   @type error_map :: %{required(String.t) => String.t}
-  @type result :: {:ok, Response.t}
-                  | {:error, :redirected, String.t}
-                  | {:error, :client_error, integer}
-                  | {:error, :server_error, integer}
-                  | {:error, :transport_error, any}
+  @type result :: {:ok, Response.t} | {:error, Error.t}
 
   @doc """
   Reports a `create_content.listing` event to Sift Science

--- a/lib/siftsciex/event/error.ex
+++ b/lib/siftsciex/event/error.ex
@@ -1,0 +1,59 @@
+defmodule Siftsciex.Event.Error do
+  @moduledoc """
+  This module encapsulates event errors so it's easier to debug problems
+  """
+  defstruct [:type, :error_status, :error_message, :time]
+
+  @type error_types :: :client_error | :server_error | :transport_error | :redirected
+
+  @type t :: %__MODULE__{
+          type: error_types(),
+          error_status: integer() | nil,
+          error_message: :atom | String.t() | nil,
+          time: DateTime.t()
+        }
+
+  @doc """
+  Build an error struct without parsing the response body
+  """
+  @spec build(error_types(), String.t()) :: t()
+  def build(type, error_message) do
+    %__MODULE__{
+      type: type,
+      error_message: error_message,
+      time: DateTime.utc_now()
+    }
+  end
+
+  @doc """
+  Parses the error response from sift events API into a struct
+  """
+  @spec from_body(error_types(), String.t()) :: t()
+  def from_body(type, body) when is_binary(body) do
+    body
+    |> Poison.decode()
+    |> case do
+      {:ok, document} ->
+        %__MODULE__{
+          type: type,
+          error_status: document["status"] || nil,
+          error_message: document["error_message"] || nil,
+          time: safe_parse_time(document["time"])
+        }
+
+      {:error, reason} ->
+        %__MODULE__{
+          type: :client_error,
+          error_status: nil,
+          error_message: "Failed to parse body: #{inspect(reason)}"
+        }
+    end
+  end
+
+  defp safe_parse_time(time) do
+    case DateTime.from_unix(time) do
+      {:ok, converted} -> converted
+      _error -> DateTime.utc_now()
+    end
+  end
+end

--- a/lib/siftsciex/event/error.ex
+++ b/lib/siftsciex/event/error.ex
@@ -26,7 +26,7 @@ defmodule Siftsciex.Event.Error do
   end
 
   @doc """
-  Parses the error response from sift events API into a struct
+  Parses the error response from Sift Events API into a struct
   """
   @spec from_body(error_types(), String.t()) :: t()
   def from_body(type, body) when is_binary(body) do

--- a/lib/siftsciex/event/payload/item.ex
+++ b/lib/siftsciex/event/payload/item.ex
@@ -100,9 +100,8 @@ defmodule Siftsciex.Event.Payload.Item do
   defp normalize({:price, value}), do: {String.to_atom("$price"), value}
   defp normalize({:size, value}), do: {String.to_atom("$size"), value}
 
-  defp convert_price(%{price: price} = data) do
-    data
-    |> Map.put(:price, Currency.as_micros(price, data.currency_code()))
+  defp convert_price(%{price: price, currency_code: currency_code} = data) do
+     Map.put(data, :price, Currency.as_micros(price, currency_code))
   end
   defp convert_price(data), do: data
 end

--- a/lib/siftsciex/score.ex
+++ b/lib/siftsciex/score.ex
@@ -52,17 +52,21 @@ defmodule Siftsciex.Score do
     |> request_url(abuse_types)
     |> @transport.get()
     |> case do
-         {:ok, %{status_code: 200} = response} ->
-           {:ok, Response.process(response.body())}
-         {:ok, %{status_code: status} = response} when status >= 300 and status <= 399 ->
-           {:error, :redirected, response.headers["Location"]}
+         {:ok, %{status_code: 200, body: body}} ->
+           {:ok, Response.process(body)}
+
+         {:ok, %{status_code: status, headers: headers}} when status >= 300 and status <= 399 ->
+           {:error, :redirected, headers["Location"]}
+
          {:ok, %{status_code: status}} when status >= 400 and status <= 499 ->
            Logger.error("Failed to Post Event, received 4xx response for configured URI")
            {:error, :client_error, status}
+
          {:ok, %{status_code: status}} when status >= 500 and status <= 500 ->
            {:error, :server_error, status}
-         {:error, error} ->
-           {:error, :transport_error, error.reason()}
+
+         {:error, %{reason: reason}} ->
+           {:error, :transport_error, reason}
        end
   end
 

--- a/lib/siftsciex/score/response/label.ex
+++ b/lib/siftsciex/score/response/label.ex
@@ -3,8 +3,6 @@ defmodule Siftsciex.Score.Response.Label do
   Represents a label in a Score response (`t:Siftsciex.Score.Response.t/0`) from Sift
   """
 
-  alias Siftsciex.Score
-
   defstruct is_bad: :empty, time: :empty, description: :empty
 
   @type abuse_type :: :payment_abuse | :account_abuse | :content_abuse | :promotion_abuse

--- a/lib/siftsciex/verification.ex
+++ b/lib/siftsciex/verification.ex
@@ -104,8 +104,8 @@ defmodule Siftsciex.Verification do
 
   defp process_response(response, endpoint) do
     case response do
-      {:ok, %{status_code: _status_code} = response} ->
-        {:ok, Response.process(response.body(), endpoint)}
+      {:ok, %{status_code: _status_code, body: body}} ->
+        {:ok, Response.process(body, endpoint)}
       {:error, error} ->
         {:error, :transport_error, error.reason()}
     end

--- a/test/siftsciex/event/error_test.exs
+++ b/test/siftsciex/event/error_test.exs
@@ -1,0 +1,42 @@
+defmodule Siftsciex.Event.ErrorTest do
+  use ExUnit.Case, async: true
+
+  alias Siftsciex.Event.Error
+
+  doctest Error
+
+  describe "from_body/2" do
+    test "creates an error struct from a json string" do
+      body = """
+      {
+        "status" : 51,
+        "error_message" : "Invalid API Key. Please check your credentials and try again.",
+        "time" : 1327604222
+      }
+      """
+
+      error = Error.from_body(:client_error, body)
+
+      assert %Error{
+               type: :client_error,
+               error_status: 51,
+               time: ~U[2012-01-26 18:57:02Z],
+               error_message: "Invalid API Key. Please check your credentials and try again."
+             } = error
+    end
+  end
+
+  describe "build/2" do
+    test "creates an error struct from a type and a message string" do
+      error = Error.build(:client_error, "no donut for you")
+
+      assert not is_nil(error.time)
+
+      assert %Error{
+               type: :client_error,
+               error_status: nil,
+               error_message: "no donut for you"
+             } = error
+    end
+  end
+end


### PR DESCRIPTION
Based on [the official docs](https://sift.com/developers/docs/curl/events-api/error-codes), add a better error handling for the events API.

Right now, when it stops working we don't really know what's happening since we can't see the sift `status` nor the `error_message` fields.

This PR also fixes a bunch of compiler warning for newer versions of elixir.