### PR TITLE
[ZION-691] Evaluate config at runtime

### DIFF
--- a/lib/siftsciex/event/account.ex
+++ b/lib/siftsciex/event/account.ex
@@ -17,7 +17,7 @@ defmodule Siftsciex.Event.Account do
 
   defstruct "$user_email": :empty,
             "$user_id": :empty,
-            "$api_key": Application.get_env(:siftsciex, :api_key),
+            "$api_key": :empty,
             "$type": :empty,
             "$name": :empty,
             "$phone": :empty,
@@ -94,6 +94,7 @@ defmodule Siftsciex.Event.Account do
 
     create()
     |> struct(normalized)
+    |> struct("$api_key": api_key())
   end
 
   @doc """
@@ -106,10 +107,10 @@ defmodule Siftsciex.Event.Account do
   ## Examples
 
       iex> Account.update_account(%{user_id: "bob", user_email: "bob@example.com"})
-      %Account{"$user_email": "bob@example.com", "$user_id": "bob", "$type": "$update_account"}
+      %Account{"$api_key": "test_key", "$user_email": "bob@example.com", "$user_id": "bob", "$type": "$update_account"}
 
       iex> Account.update_account(%{user_id: "bob", payment_methods: [%{payment_type: :cash}]})
-      %Account{"$user_id": "bob", "$type": "$update_account", "$payment_methods": [%PaymentMethod{"$payment_type": "$cash"}]}
+      %Account{"$api_key": "test_key", "$user_id": "bob", "$type": "$update_account", "$payment_methods": [%PaymentMethod{"$payment_type": "$cash"}]}
 
   """
   @spec update_account(data) :: __MODULE__.t
@@ -118,6 +119,7 @@ defmodule Siftsciex.Event.Account do
 
     update()
     |> struct(normalized)
+    |> struct("$api_key": api_key())
   end
 
   defp create, do: %__MODULE__{"$type": "$create_account"}

--- a/lib/siftsciex/event/content.ex
+++ b/lib/siftsciex/event/content.ex
@@ -9,7 +9,7 @@ defmodule Siftsciex.Event.Content do
   alias Siftsciex.Event.Payload.{Listing, Message}
 
   defstruct "$type": :empty,
-            "$api_key": Application.get_env(:siftsciex, :api_key),
+            "$api_key": :empty,
             "$user_id": :empty,
             "$content_id": :empty,
             "$account_type": :empty,
@@ -135,7 +135,9 @@ defmodule Siftsciex.Event.Content do
 
   defp populate_context(record, %{user_id: user, content_id: content} = data) do
     record
-    |> struct(["$user_id": user,
+    |> struct([
+               "$api_key": api_key(),
+               "$user_id": user,
                "$content_id": content,
                "$ip": lookup(data, :ip),
                "$session_id": lookup(data, :session_id),

--- a/lib/siftsciex/event/login.ex
+++ b/lib/siftsciex/event/login.ex
@@ -8,7 +8,7 @@ defmodule Siftsciex.Event.Login do
   alias Siftsciex.Event.Payload.{App, Browser}
 
   defstruct "$type": "$login",
-            "$api_key": api_key(),
+            "$api_key": :empty,
             "$user_id": :empty,
             "$session_id": :empty,
             "$login_status": :empty,
@@ -116,7 +116,7 @@ defmodule Siftsciex.Event.Login do
   ## Examples
 
       iex> Siftsciex.Event.Login.create(%{user_id: "jack.shephard", login_status: :success})
-      {:ok, %Siftsciex.Event.Login{"$type": "$login", "$user_id": "jack.shephard", "$login_status": "$success"}}
+      {:ok, %Siftsciex.Event.Login{"$api_key": "test_key", "$type": "$login", "$user_id": "jack.shephard", "$login_status": "$success"}}
 
       iex> Siftsciex.Event.Login.create(%{user_id: "jack.shephard", failure_reason: :bad_arg})
       {:error, "invalid failure_reason: bad_arg"}
@@ -139,7 +139,12 @@ defmodule Siftsciex.Event.Login do
 
     case normalized do
       %{} = _normalized ->
-        {:ok, struct(__MODULE__, normalized)}
+        value =
+          __MODULE__
+        |> struct(normalized)
+        |> struct("$api_key": api_key())
+
+        {:ok,value}
 
       {:error, error} ->
         {:error, error}


### PR DESCRIPTION
Changes the events API handler so they evaluate the `$api_key` at runtime, instead of compile time.

This change is required to properly set the application keys during runtime, fetching from the environment.